### PR TITLE
Update winapi stubs

### DIFF
--- a/peloader/winapi/Files.c
+++ b/peloader/winapi/Files.c
@@ -117,6 +117,27 @@ static HANDLE WINAPI CreateFileW(PWCHAR lpFileName, DWORD dwDesiredAccess, DWORD
     return FileHandle ? FileHandle : INVALID_HANDLE_VALUE;
 }
 
+/**
+ * TODO: handle 64 bit 
+ */
+static DWORD WINAPI SetFilePointer(HANDLE hFile, LONG liDistanceToMove,  LONG *lpDistanceToMoveHigh, DWORD dwMoveMethod)
+{
+    int result;
+
+    DebugLog("%p, %llu, %p, %u", hFile, liDistanceToMove, lpDistanceToMoveHigh, dwMoveMethod);
+
+    result = fseek(hFile, liDistanceToMove, dwMoveMethod);
+
+    DWORD pos = ftell(hFile);
+
+    if (lpDistanceToMoveHigh) {
+        *lpDistanceToMoveHigh = (LONG *)NULL;
+    }
+
+    return pos;
+}
+
+
 static BOOL WINAPI SetFilePointerEx(HANDLE hFile, uint64_t liDistanceToMove,  uint64_t *lpNewFilePointer, DWORD dwMoveMethod)
 {
     int result;

--- a/peloader/winapi/Files.c
+++ b/peloader/winapi/Files.c
@@ -173,7 +173,7 @@ static DWORD WINAPI SetFilePointer(HANDLE hFile, LONG liDistanceToMove,  LONG *l
     DWORD pos = ftell(hFile);
 
     if (lpDistanceToMoveHigh) {
-        *lpDistanceToMoveHigh = (LONG *)NULL;
+        *lpDistanceToMoveHigh = 0;
     }
 
     return pos;

--- a/peloader/winapi/Files.c
+++ b/peloader/winapi/Files.c
@@ -305,6 +305,7 @@ DECLARE_CRT_EXPORT("GetFileVersionInfoSizeExW", GetFileVersionInfoSizeExW);
 DECLARE_CRT_EXPORT("GetFileAttributesW", GetFileAttributesW);
 DECLARE_CRT_EXPORT("GetFileAttributesExW", GetFileAttributesExW);
 DECLARE_CRT_EXPORT("CreateFileW", CreateFileW);
+DECLARE_CRT_EXPORT("SetFilePointer", SetFilePointer);
 DECLARE_CRT_EXPORT("SetFilePointerEx", SetFilePointerEx);
 DECLARE_CRT_EXPORT("CloseHandle", CloseHandle);
 DECLARE_CRT_EXPORT("ReadFile", ReadFile);

--- a/peloader/winapi/GetStartupInfoW.c
+++ b/peloader/winapi/GetStartupInfoW.c
@@ -32,13 +32,21 @@ typedef struct _STARTUPINFO {
   HANDLE hStdError;
 } STARTUPINFO, *LPSTARTUPINFO;
 
+
+STATIC void WINAPI GetStartupInfoA(LPSTARTUPINFO lpStartupInfo)
+{
+    memset(lpStartupInfo, 0, sizeof *lpStartupInfo);
+
+    DebugLog("GetStartupInfoA(%p)", lpStartupInfo);
+}
+
+
 STATIC void WINAPI GetStartupInfoW(LPSTARTUPINFO lpStartupInfo)
 {
     memset(lpStartupInfo, 0, sizeof *lpStartupInfo);
 
     DebugLog("GetStartupInfoW(%p)", lpStartupInfo);
 }
-
 
 STATIC PVOID WINAPI GetCommandLineA(void)
 {
@@ -52,6 +60,7 @@ STATIC PVOID WINAPI GetCommandLineW(void)
     return L"totallylegit.exe notfake very real";
 }
 
+DECLARE_CRT_EXPORT("GetStartupInfoA", GetStartupInfoA);
 DECLARE_CRT_EXPORT("GetStartupInfoW", GetStartupInfoW);
 DECLARE_CRT_EXPORT("GetCommandLineA", GetCommandLineA);
 DECLARE_CRT_EXPORT("GetCommandLineW", GetCommandLineW);

--- a/peloader/winapi/Handle.c
+++ b/peloader/winapi/Handle.c
@@ -23,4 +23,12 @@ STATIC BOOL WINAPI DuplicateHandle(HANDLE hSourceProcessHandle, HANDLE hSourceHa
     return TRUE;
 }
 
+STATIC UINT WINAPI SetHandleCount(UINT handleCount)
+{
+    DebugLog("%u", handleCount);
+    return handleCount;
+}
+
+
 DECLARE_CRT_EXPORT("DuplicateHandle", DuplicateHandle);
+DECLARE_CRT_EXPORT("SetHandleCount", SetHandleCount);

--- a/peloader/winapi/Strings.c
+++ b/peloader/winapi/Strings.c
@@ -94,6 +94,16 @@ STATIC int WINAPI WideCharToMultiByte(UINT CodePage, DWORD dwFlags, PVOID lpWide
     return 0;
 }
 
+STATIC BOOL WINAPI GetStringTypeA(DWORD locale, DWORD dwInfoType, PUSHORT lpSrcStr, int cchSrc, PUSHORT lpCharType)
+{
+    DebugLog("%u, %u, %p, %d, %p", locale, dwInfoType, lpSrcStr, cchSrc, lpCharType);
+
+    memset(lpCharType, 1, cchSrc * sizeof(USHORT));
+
+    return FALSE;
+}
+
+
 STATIC BOOL WINAPI GetStringTypeW(DWORD dwInfoType, PUSHORT lpSrcStr, int cchSrc, PUSHORT lpCharType)
 {
     DebugLog("%u, %p, %d, %p", dwInfoType, lpSrcStr, cchSrc, lpCharType);
@@ -125,6 +135,7 @@ STATIC PVOID WINAPI UuidFromStringW(PUSHORT StringUuid, PBYTE Uuid)
 
 DECLARE_CRT_EXPORT("MultiByteToWideChar", MultiByteToWideChar);
 DECLARE_CRT_EXPORT("WideCharToMultiByte", WideCharToMultiByte);
+DECLARE_CRT_EXPORT("GetStringTypeA", GetStringTypeA);
 DECLARE_CRT_EXPORT("GetStringTypeW", GetStringTypeW);
 DECLARE_CRT_EXPORT("RtlInitUnicodeString", RtlInitUnicodeString);
 DECLARE_CRT_EXPORT("UuidFromStringW", UuidFromStringW);

--- a/peloader/winapi/Strings.c
+++ b/peloader/winapi/Strings.c
@@ -86,6 +86,8 @@ STATIC int WINAPI WideCharToMultiByte(UINT CodePage, DWORD dwFlags, PVOID lpWide
         strcpy(lpMultiByteStr, ansi);
         free(ansi);
         return strlen(lpMultiByteStr) + 1;
+    } else if (!lpMultiByteStr && cbMultiByte == 0) {
+        return strlen(ansi) + 1;
     }
 
     free(ansi);

--- a/peloader/winapi/Strings.c
+++ b/peloader/winapi/Strings.c
@@ -87,7 +87,9 @@ STATIC int WINAPI WideCharToMultiByte(UINT CodePage, DWORD dwFlags, PVOID lpWide
         free(ansi);
         return strlen(lpMultiByteStr) + 1;
     } else if (!lpMultiByteStr && cbMultiByte == 0) {
-        return strlen(ansi) + 1;
+        int len = strlen(ansi) + 1;
+        free(ansi);
+        return len;
     }
 
     free(ansi);


### PR DESCRIPTION
Additional winapi stubs and fixes the return value of `WideCharToMultiByte`.

Resolves #40.