### PR TITLE
IsDebuggerPresent -> IsGdbPresent

### DIFF
--- a/mpclient.c
+++ b/mpclient.c
@@ -154,7 +154,7 @@ int main(int argc, char **argv, char **envp)
 #endif
     } else {
         // Calculate the commands needed to get export and map symbols visible in gdb.
-        if (IsDebuggerPresent()) {
+        if (IsGdbPresent()) {
             LogMessage("GDB: add-symbol-file %s %#x+%#x",
                        image.name,
                        image.image,

--- a/mpscript.c
+++ b/mpscript.c
@@ -120,7 +120,7 @@ int main(int argc, char **argv, char **envp)
     }
 
     // Calculate the commands needed to get export and map symbols visible in gdb.
-    if (IsDebuggerPresent()) {
+    if (IsGdbPresent()) {
         LogMessage("GDB: add-symbol-file %s %#x+%#x",
                    image.name,
                    image.image,

--- a/peloader/util.c
+++ b/peloader/util.c
@@ -30,7 +30,7 @@
 #include "util.h"
 
 // Quick check if I'm running under GDB.
-bool IsDebuggerPresent()
+bool IsGdbPresent()
 {
     char *statusline;
     FILE *status;

--- a/peloader/util.h
+++ b/peloader/util.h
@@ -2,7 +2,7 @@
 #define __UTIL_H
 #pragma once
 
-bool IsDebuggerPresent();
+bool IsGdbPresent();
 
 #ifdef __linux__
 #define __thiscall      __attribute__((thiscall))

--- a/peloader/winapi/Debugger.c
+++ b/peloader/winapi/Debugger.c
@@ -1,0 +1,27 @@
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdbool.h>
+#include <search.h>
+#include <assert.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include "winnt_types.h"
+#include "pe_linker.h"
+#include "ntoskernel.h"
+#include "log.h"
+#include "winexports.h"
+#include "util.h"
+#include "winstrings.h"
+
+static BOOL WINAPI IsDebuggerPresent()
+{
+    DebugLog("");
+    return false;
+}
+
+DECLARE_CRT_EXPORT("IsDebuggerPresent", IsDebuggerPresent);


### PR DESCRIPTION
The util function IsDebuggerPresent (// Quick check if I'm running under GDB.) is conflicting with the homonym Windows API.