### PR TITLE
fix: reset num_pe_exports on export dir parsing

### DIFF
--- a/peloader/pe_linker.c
+++ b/peloader/pe_linker.c
@@ -322,6 +322,7 @@ static int read_exports(struct pe_image *pe)
                                       export_dir_table->AddressOfNameOrdinals);
 
         pe_exports = calloc(export_dir_table->NumberOfNames, sizeof(struct pe_exports));
+        num_pe_exports = 0;
 
         for (i = 0; i < export_dir_table->NumberOfNames; i++) {
                 uint32_t address = ((uint32_t *) (pe->image + export_dir_table->AddressOfFunctions))[*ordinal_table];


### PR DESCRIPTION
I was getting segfault here while loading multiple dlls, as num_pe_exports was exceeding pe_exports size on some point