### PR TITLE
make loadlibrary work in c++

### DIFF
--- a/include/rsignal.h
+++ b/include/rsignal.h
@@ -1,5 +1,5 @@
 #ifndef __RSIGNAL_H
-#define __RESIGNAL_H
+#define __RSIGNAL_H
 
 #define RSIG_BASE                             0x4000
 #define RSIG_RESERVED1                        0x4003

--- a/include/scanreply.h
+++ b/include/scanreply.h
@@ -45,7 +45,7 @@ typedef struct _SCANSTRUCT {
 } SCANSTRUCT, *PSCANSTRUCT;
 
 typedef struct _SCAN_REPLY {
-    DWORD   (*EngineScanCallback)(PSCANSTRUCT this);
+    DWORD   (*EngineScanCallback)(PSCANSTRUCT _this);
     DWORD   field_4;
     DWORD   UserPtr;
     DWORD   field_C;

--- a/include/streambuffer.h
+++ b/include/streambuffer.h
@@ -93,13 +93,13 @@ enum {
 
 typedef struct _STREAMBUFFER_DESCRIPTOR {
     PVOID  UserPtr;
-    DWORD  (* Read)(PVOID this, uint64_t Offset, PVOID Buffer, DWORD Size, PDWORD SizeRead);
-    DWORD  (* Write)(PVOID this, uint64_t Offset, PVOID Buffer, DWORD Size, PDWORD TotalWritten);
-    DWORD  (* GetSize)(PVOID this, uint64_t *FileSize);
-    DWORD  (* SetSize)(PVOID this, uint64_t *FileSize);
-    PWCHAR (* GetName)(PVOID this);
-    DWORD  (* SetAttributes)(PVOID this, DWORD Attribute, PVOID Data, DWORD DataSize);
-    DWORD  (* GetAttributes)(PVOID this, DWORD Attribute, PVOID Data, DWORD DataSize, PDWORD DataSizeWritten);
+    DWORD  (* Read)(PVOID _this, uint64_t Offset, PVOID Buffer, DWORD Size, PDWORD SizeRead);
+    DWORD  (* Write)(PVOID _this, uint64_t Offset, PVOID Buffer, DWORD Size, PDWORD TotalWritten);
+    DWORD  (* GetSize)(PVOID _this, uint64_t *FileSize);
+    DWORD  (* SetSize)(PVOID _this, uint64_t *FileSize);
+    PWCHAR (* GetName)(PVOID _this);
+    DWORD  (* SetAttributes)(PVOID _this, DWORD Attribute, PVOID Data, DWORD DataSize);
+    DWORD  (* GetAttributes)(PVOID _this, DWORD Attribute, PVOID Data, DWORD DataSize, PDWORD DataSizeWritten);
 } STREAMBUFFER_DESCRIPTOR, *PSTREAMBUFFER_DESCRIPTOR;
 
 typedef struct _SCANSTREAM_PARAMS {

--- a/mpclient.c
+++ b/mpclient.c
@@ -178,7 +178,13 @@ int main(int argc, char **argv, char **envp)
         errx(EXIT_FAILURE, "Failed to resolve mpengine entrypoint");
     }
 
-    EXCEPTION_DISPOSITION ExceptionHandler(struct _EXCEPTION_RECORD *ExceptionRecord,
+#ifdef __cplusplus
+    // fix C++ error: function definition is not allowed here
+    PEXCEPTION_HANDLER ExceptionHandler = reinterpret_cast<PEXCEPTION_HANDLER>(+[](
+#else
+    EXCEPTION_DISPOSITION ExceptionHandler(
+#endif
+            struct _EXCEPTION_RECORD *ExceptionRecord,
             struct _EXCEPTION_FRAME *EstablisherFrame,
             struct _CONTEXT *ContextRecord,
             struct _EXCEPTION_FRAME **DispatcherContext)
@@ -186,6 +192,9 @@ int main(int argc, char **argv, char **envp)
         LogMessage("Toplevel Exception Handler Caught Exception");
         abort();
     }
+#ifdef __cplusplus
+    );
+#endif
 
     VOID ResourceExhaustedHandler(int Signal)
     {

--- a/mpclient.c
+++ b/mpclient.c
@@ -91,21 +91,21 @@ static DWORD EngineScanCallback(PSCANSTRUCT Scan)
     return 0;
 }
 
-static DWORD ReadStream(PVOID this, ULONGLONG Offset, PVOID Buffer, DWORD Size, PDWORD SizeRead)
+static DWORD ReadStream(PVOID _this, ULONGLONG Offset, PVOID Buffer, DWORD Size, PDWORD SizeRead)
 {
-    fseek(this, Offset, SEEK_SET);
-    *SizeRead = fread(Buffer, 1, Size, this);
+    fseek(_this, Offset, SEEK_SET);
+    *SizeRead = fread(Buffer, 1, Size, _this);
     return TRUE;
 }
 
-static DWORD GetStreamSize(PVOID this, PULONGLONG FileSize)
+static DWORD GetStreamSize(PVOID _this, PULONGLONG FileSize)
 {
-    fseek(this, 0, SEEK_END);
-    *FileSize = ftell(this);
+    fseek(_this, 0, SEEK_END);
+    *FileSize = ftell(_this);
     return TRUE;
 }
 
-static PWCHAR GetStreamName(PVOID this)
+static PWCHAR GetStreamName(PVOID _this)
 {
     return L"input";
 }

--- a/mpclient.c
+++ b/mpclient.c
@@ -234,10 +234,12 @@ int main(int argc, char **argv, char **envp)
 
     BootParams.ClientVersion = BOOTENGINE_PARAMS_VERSION;
     BootParams.Attributes    = BOOT_ATTR_NORMAL;
-    BootParams.SignatureLocation = L"engine";
-    BootParams.ProductName = L"Legitimate Antivirus";
-    EngineConfig.QuarantineLocation = L"quarantine";
-    EngineConfig.Inclusions = L"*.*";
+    // fix C++ error: assigning to 'PWCHAR' from incompatible type
+    //BootParams.SignatureLocation = L"engine";
+    BootParams.SignatureLocation = (PWCHAR)"engine";
+    BootParams.ProductName = (PWCHAR)"Legitimate Antivirus";
+    EngineConfig.QuarantineLocation = (PWCHAR)"quarantine";
+    EngineConfig.Inclusions = (PWCHAR)"*.*";
     EngineConfig.EngineFlags = 1 << 1;
     BootParams.EngineInfo = &EngineInfo;
     BootParams.EngineConfig = &EngineConfig;

--- a/mpclient.c
+++ b/mpclient.c
@@ -196,10 +196,18 @@ int main(int argc, char **argv, char **envp)
     );
 #endif
 
+#ifdef __cplusplus
+    // fix C++ error: function definition is not allowed here
+    auto ResourceExhaustedHandler = [](int Signal)
+#else
     VOID ResourceExhaustedHandler(int Signal)
+#endif
     {
         errx(EXIT_FAILURE, "Resource Limits Exhausted, Signal %s", strsignal(Signal));
     }
+#ifdef __cplusplus
+    ;
+#endif
 
     setup_nt_threadinfo(ExceptionHandler);
 

--- a/mpclient.c
+++ b/mpclient.c
@@ -145,7 +145,12 @@ int main(int argc, char **argv, char **envp)
 
     // Fetch the headers to get base offsets.
     DosHeader   = (PIMAGE_DOS_HEADER) image.image;
+#ifdef __cplusplus
+    // fix: error: arithmetic on a pointer to void
+    PeHeader    = (PIMAGE_NT_HEADERS)(static_cast<char*>(image.image) + DosHeader->e_lfanew);
+#else
     PeHeader    = (PIMAGE_NT_HEADERS)(image.image + DosHeader->e_lfanew);
+#endif
 
     // Load any additional exports.
     if (!process_extra_exports(image.image, PeHeader->OptionalHeader.BaseOfCode, "engine/mpengine.map")) {

--- a/mpclient.c
+++ b/mpclient.c
@@ -107,7 +107,7 @@ static DWORD GetStreamSize(PVOID _this, PULONGLONG FileSize)
 
 static PWCHAR GetStreamName(PVOID _this)
 {
-    return L"input";
+    return (PWCHAR)"input";
 }
 
 // These are available for pintool.

--- a/mpclient.c
+++ b/mpclient.c
@@ -93,15 +93,15 @@ static DWORD EngineScanCallback(PSCANSTRUCT Scan)
 
 static DWORD ReadStream(PVOID _this, ULONGLONG Offset, PVOID Buffer, DWORD Size, PDWORD SizeRead)
 {
-    fseek(_this, Offset, SEEK_SET);
-    *SizeRead = fread(Buffer, 1, Size, _this);
+    fseek((FILE *)_this, Offset, SEEK_SET);
+    *SizeRead = fread((FILE *)Buffer, 1, Size, (FILE *)_this);
     return TRUE;
 }
 
 static DWORD GetStreamSize(PVOID _this, PULONGLONG FileSize)
 {
-    fseek(_this, 0, SEEK_END);
-    *FileSize = ftell(_this);
+    fseek((FILE *)_this, 0, SEEK_END);
+    *FileSize = ftell((FILE *)_this);
     return TRUE;
 }
 

--- a/peloader/ntoskernel.h
+++ b/peloader/ntoskernel.h
@@ -43,7 +43,7 @@ struct pe_image {
         char name[128];
         BOOL WINAPI (*entry)(PVOID hinstDLL, DWORD fdwReason, PVOID lpvReserved);
         void *image;
-        int size;
+        size_t size;
         int type;
 
         IMAGE_NT_HEADERS *nt_hdr;

--- a/peloader/winnt_types.h
+++ b/peloader/winnt_types.h
@@ -144,7 +144,7 @@ typedef uint8_t         *PBYTE;
 typedef uint8_t         *LPBYTE;
 typedef int8_t          CHAR;
 typedef char            *PCHAR;
-typedef wchar_t         WCHAR;
+typedef uint16_t        WCHAR;
 typedef CHAR            *LPSTR;
 typedef const char      *LPCSTR;
 typedef WCHAR           *LPWSTR;

--- a/peloader/winnt_types.h
+++ b/peloader/winnt_types.h
@@ -1103,7 +1103,15 @@ IoSetCompletionRoutine(struct irp *irp, void *routine, void *context,
                        BOOLEAN success, BOOLEAN error, BOOLEAN cancel)
 {
         struct io_stack_location *irp_sl = IoGetNextIrpStackLocation(irp);
+
+#ifdef __cplusplus
+        // https://stackoverflow.com/questions/1096341/function-pointers-casting-in-c
+        // fix: error: assigning to x from y converts between void pointer and function pointer
+        irp_sl->completion_routine = (typeof(irp_sl->completion_routine))(routine);
+#else
         irp_sl->completion_routine = routine;
+#endif
+
         irp_sl->context = context;
         irp_sl->control = 0;
         if (success)


### PR DESCRIPTION
make mpclient.c compile with clang++/g++
this is needed to use loadlibrary in c++ projects

not tested if mpclient.c still compiles with clang/gcc
maybe this needs more `#ifdef __cplusplus` branches

